### PR TITLE
Fix Unicode double-encode bug

### DIFF
--- a/chatexchange6/browser.py
+++ b/chatexchange6/browser.py
@@ -111,11 +111,11 @@ class Browser(object):
 
     def get_soup(self, url, data=None, headers=None, with_chat_root=True):
         response = self.get(url, data, headers, with_chat_root)
-        return BeautifulSoup(response.content, "html.parser")
+        return BeautifulSoup(response.text, "html.parser")
 
     def post_soup(self, url, data=None, headers=None, with_chat_root=True):
         response = self.post(url, data, headers, with_chat_root)
-        return BeautifulSoup(response.content, "html.parser")
+        return BeautifulSoup(response.text, "html.parser")
 
     def post_fkeyed(self, url, data=None, headers=None):
         if data is None:
@@ -196,7 +196,7 @@ class Browser(object):
             # no prompt for us to handle
             return prompt_response
 
-        prompt_soup = BeautifulSoup(prompt_response.content, "html.parser")
+        prompt_soup = BeautifulSoup(prompt_response.text, "html.parser")
 
         data = {
             'session': prompt_soup.find('input', {'name': 'session'})['value'],


### PR DESCRIPTION
Using `response.content` (where `response` is a reponse from a `requests` request) causes the data to be double-encoded in UTF-8 in Python 3. Changing this to `response.text` fixes this bug.
